### PR TITLE
Terrible regex hack to remove EJSON date encoding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,5 +27,5 @@ jobs:
           command: gradle distTar
       - aws-s3/copy:
           from: build/distributions/kafka-connect-mongo-*.tgz
-          to: 's3://artifacts.reactioncommerce.com/kafka-connect-mongo'
+          to: 's3://artifacts.reactioncommerce.com/kafka-connect-mongo/'
           arguments: "--acl public-read"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,39 @@
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:8-jdk
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "build.gradle" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: gradle dependencies
+
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: v1-dependencies-{{ checksum "build.gradle" }}
+
+      - run: gradle jar
+      - store_artifacts:
+          path: ~/repo/build/libs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,38 +2,35 @@ version: 2
 jobs:
   build:
     docker:
-      # specify the version you desire here
       - image: circleci/openjdk:8-jdk
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
-
     working_directory: ~/repo
-
     environment:
-      # Customize the JVM maximum heap limit
       JVM_OPTS: -Xmx3200m
       TERM: dumb
-
     steps:
       - checkout
-
       # Download and cache dependencies
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "build.gradle" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
-
       - run: gradle dependencies
-
       - save_cache:
           paths:
             - ~/.gradle
           key: v1-dependencies-{{ checksum "build.gradle" }}
-
-      - run: gradle distTar
-      - store_artifacts:
-          path: ~/repo/build/distributions
+      - run:
+          name: Build Distribution
+          command: gradle distTar
+      - run:
+          name: Install S3 Uploader
+          command: |
+            url='https://github.com/matthew-andrews/s3up/releases/download/v1.0.5/s3up_linux_amd64'
+            curl --silent --location --fail "${url}" > /tmp/s3up
+            chmod 755 /tmp/s3up
+      - run:
+          name: Upload to S3
+          command: |
+            cd build/distributions
+            /tmp/s3up --bucket artifacts.reactioncommerce.com --destination /kafka-connect-mongo kafka-connect-mongo-*.tgz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
-version: 2
+version: 2.1
+orbs:
+  aws-s3: circleci/aws-s3@volatile
 jobs:
   build:
     docker:
@@ -23,14 +25,7 @@ jobs:
       - run:
           name: Build Distribution
           command: gradle distTar
-      - run:
-          name: Install S3 Uploader
-          command: |
-            url='https://github.com/matthew-andrews/s3up/releases/download/v1.0.5/s3up_linux_amd64'
-            curl --silent --location --fail "${url}" > /tmp/s3up
-            chmod 755 /tmp/s3up
-      - run:
-          name: Upload to S3
-          command: |
-            cd build/distributions
-            /tmp/s3up --bucket artifacts.reactioncommerce.com --destination /kafka-connect-mongo kafka-connect-mongo-*.tgz
+      - aws-s3/copy:
+          from: build/distributions/kafka-connect-mongo-*.tgz
+          to: 's3://artifacts.reactioncommerce.com/kafka-connect-mongo'
+          arguments: "--acl public-read"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,6 @@ jobs:
             - ~/.gradle
           key: v1-dependencies-{{ checksum "build.gradle" }}
 
-      - run: gradle jar
+      - run: gradle distTar
       - store_artifacts:
-          path: ~/repo/build/libs
+          path: ~/repo/build/distributions

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.reaction'
-version '1.8.0'
+version '1.9.0'
 
 buildscript {
     ext.kotlin_version = '1.2.60'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.reaction'
-version '1.9.0'
+version '1.10.0'
 
 buildscript {
     ext.kotlin_version = '1.2.60'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
-group 'com.teambition'
-version '1.7.9'
+group 'com.reaction'
+version '1.8.0'
 
 buildscript {
     ext.kotlin_version = '1.2.60'

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/database/DatabaseReader.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/database/DatabaseReader.kt
@@ -61,7 +61,7 @@ class DatabaseReader(val uri: String,
      */
     override fun run() {
         if (!start.finishedImport && initialImport) {
-            executor.execute { importCollection(db, start.objectId) }
+            executor.execute { importCollection(db, start.objectId.toString()) }
             executor.awaitTermination(1, TimeUnit.DAYS)
         }
         log.info("Querying oplog on $db from ${start.ts}")
@@ -104,7 +104,7 @@ class DatabaseReader(val uri: String,
         }
     }
 
-    private fun importCollection(db: String, objectId: ObjectId) {
+    private fun importCollection(db: String, objectId: String) {
         var offsetCount = 0L
         var offsetId = objectId
         val mongoCollection = getNSCollection(db)
@@ -117,7 +117,7 @@ class DatabaseReader(val uri: String,
             .asSequence()
             .forEach { document ->
                 messages.add(formatAsOpLog(document))
-                offsetId = document["_id"] as ObjectId
+                offsetId = document["_id"] as String
                 offsetCount += 1
                 while (messages.size > maxMessageSize) {
                     log.warn("Message overwhelm! database {}, docs {}, messages {}",
@@ -166,7 +166,7 @@ class DatabaseReader(val uri: String,
     private fun findOneById(doc: Document): Document? {
         try {
             val nsCollection = getNSCollection(doc["ns"].toString())
-            val id = (doc["o2"] as Document)["_id"] as ObjectId
+            val id = (doc["o2"] as Document)["_id"] as String
 
             val docs = nsCollection.find(Filters.eq("_id", id)).into(ArrayList<Document>())
 

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
@@ -98,7 +98,7 @@ abstract class AbstractMongoSourceTask : SourceTask() {
         while (!messages.isEmpty() && records.size < batchSize) {
             val message = messages.poll()
             val id = (message["o"] as Document)
-                .let { it["_id"] as ObjectId }
+                .let { it["_id"] as String }
                 .toString()
             try {
                 val struct = getStruct(message)
@@ -136,7 +136,7 @@ abstract class AbstractMongoSourceTask : SourceTask() {
 
     private fun getOffset(message: Document): Map<String, String> {
         val timestamp = message["ts"] as BsonTimestamp
-        val objectId = (message["o"] as Document)["_id"] as ObjectId
+        val objectId = (message["o"] as Document)["_id"] as String
         val finishedImport = message["initialImport"] == null
         val offsetVal = MongoSourceOffset.toOffsetString(timestamp, objectId, finishedImport)
         return Collections.singletonMap(StructUtil.getDB(message), offsetVal)
@@ -161,7 +161,7 @@ abstract class AbstractMongoSourceTask : SourceTask() {
         val struct = Struct(schema)
         val bsonTimestamp = message["ts"] as BsonTimestamp
         val body = message["o"] as Document
-        val id = (body["_id"] as ObjectId).toString()
+        val id = body["_id"] as String
         struct.put("ts", bsonTimestamp.time)
         struct.put("inc", bsonTimestamp.inc)
         struct.put("id", id)

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
@@ -65,7 +65,7 @@ abstract class AbstractMongoSourceTask : SourceTask() {
                 ?: throw Exception("Invalid config $SCHEMA_REGISTRY_URL_CONFIG")
             val schemaRegistryClient = RestService(schemaRegistryUrl)
             log.info("Init avro schemas")
-            databases.map { it.replace(".", "_").toLowerCase() }
+            databases.map { it.replace(".", "_") }
                 .forEach {
                     try {
                         val restSchema = schemaRegistryClient.getLatestVersion("${topicPrefix}_$it-value")

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
@@ -65,7 +65,7 @@ abstract class AbstractMongoSourceTask : SourceTask() {
                 ?: throw Exception("Invalid config $SCHEMA_REGISTRY_URL_CONFIG")
             val schemaRegistryClient = RestService(schemaRegistryUrl)
             log.info("Init avro schemas")
-            databases.map { it.replace(".", "_") }
+            databases.map { it.replace(".", "_").toLowerCase() }
                 .forEach {
                     try {
                         val restSchema = schemaRegistryClient.getLatestVersion("${topicPrefix}_$it-value")

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
@@ -136,7 +136,7 @@ abstract class AbstractMongoSourceTask : SourceTask() {
 
     private fun getOffset(message: Document): Map<String, String> {
         val timestamp = message["ts"] as BsonTimestamp
-        val sortField = (message["o"] as Document)["updatedAt"] as String
+        val sortField = (message["o"] as Document)["updatedAt"].toString()
         val finishedImport = message["initialImport"] == null
         val offsetVal = MongoSourceOffset.toOffsetString(timestamp, sortField, finishedImport)
         return Collections.singletonMap(StructUtil.getDB(message), offsetVal)

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
@@ -43,7 +43,6 @@ abstract class AbstractMongoSourceTask : SourceTask() {
     private var sleepTime = 50L
     private var maxSleepTime = 10000L
     private var analyzeSchema = false
-    private val ejsonDateAsLong: Regex = Regex("\\{ \"\\\$date\" : (\\d+) }")
 
     override fun version(): String = MongoSourceConnector().version()
     protected var unrecoverable: Throwable? = null
@@ -171,8 +170,7 @@ abstract class AbstractMongoSourceTask : SourceTask() {
         if (message["op"].toString() == "d") {
             struct.put("object", null)
         } else {
-            val json = ejsonDateAsLong.replace((message["o"] as Document).toJson(), "\$1")
-            struct.put("object", json)
+            struct.put("object", StructUtil.dateTimeAsMillis((message["o"] as Document).toJson()))
         }
         return struct
     }

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
@@ -43,6 +43,7 @@ abstract class AbstractMongoSourceTask : SourceTask() {
     private var sleepTime = 50L
     private var maxSleepTime = 10000L
     private var analyzeSchema = false
+    private val ejsonDateAsLong: Regex = Regex("\\{ \"\\\$date\" : (\\d+) }")
 
     override fun version(): String = MongoSourceConnector().version()
     protected var unrecoverable: Throwable? = null
@@ -170,7 +171,8 @@ abstract class AbstractMongoSourceTask : SourceTask() {
         if (message["op"].toString() == "d") {
             struct.put("object", null)
         } else {
-            struct.put("object", (message["o"] as Document).toJson())
+            val json = ejsonDateAsLong.replace((message["o"] as Document).toJson(), "\$1")
+            struct.put("object", json)
         }
         return struct
     }

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/source/AbstractMongoSourceTask.kt
@@ -136,9 +136,9 @@ abstract class AbstractMongoSourceTask : SourceTask() {
 
     private fun getOffset(message: Document): Map<String, String> {
         val timestamp = message["ts"] as BsonTimestamp
-        val objectId = (message["o"] as Document)["_id"] as String
+        val sortField = (message["o"] as Document)["updatedAt"] as String
         val finishedImport = message["initialImport"] == null
-        val offsetVal = MongoSourceOffset.toOffsetString(timestamp, objectId, finishedImport)
+        val offsetVal = MongoSourceOffset.toOffsetString(timestamp, sortField, finishedImport)
         return Collections.singletonMap(StructUtil.getDB(message), offsetVal)
     }
 

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/source/MongoSourceOffset.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/source/MongoSourceOffset.kt
@@ -17,7 +17,7 @@ class MongoSourceOffset(offsetStr: String?) {
     val ts = BsonTimestamp(timestamp, inc)
 
     // To be compatible with old format
-    val objectId: ObjectId = if (pieces != null && pieces.size > 2) ObjectId(pieces[2]) else ObjectId("000000000000000000000000")
+    val objectId: String = if (pieces != null && pieces.size > 2) pieces[2] else "000000000000000000000000"
     val finishedImport: Boolean = if (pieces != null && pieces.size > 3) parseInt(pieces[3]) > 0 else pieces != null
 
     override fun toString(): String {
@@ -31,7 +31,7 @@ class MongoSourceOffset(offsetStr: String?) {
          * Start from current time will skip a lot of redundant scan on oplog
          * Format: LATEST_TIMESTAMP,INC,OBJECT_ID,FINISH_IMPORT
          */
-        fun toOffsetString(ts: BsonTimestamp, objectId: ObjectId, finishedImport: Boolean): String {
+        fun toOffsetString(ts: BsonTimestamp, objectId: String, finishedImport: Boolean): String {
             val finishedFlag = if (finishedImport) 1 else -1
             return "${ts.time}$SPLITOR${ts.inc}$SPLITOR$objectId$SPLITOR$finishedFlag"
         }

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/source/MongoSourceOffset.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/source/MongoSourceOffset.kt
@@ -17,11 +17,11 @@ class MongoSourceOffset(offsetStr: String?) {
     val ts = BsonTimestamp(timestamp, inc)
 
     // To be compatible with old format
-    val objectId: String = if (pieces != null && pieces.size > 2) pieces[2] else "000000000000000000000000"
+    val sortField: String = if (pieces != null && pieces.size > 2) pieces[2] else ""
     val finishedImport: Boolean = if (pieces != null && pieces.size > 3) parseInt(pieces[3]) > 0 else pieces != null
 
     override fun toString(): String {
-        return toOffsetString(ts, objectId, finishedImport)
+        return toOffsetString(ts, sortField, finishedImport)
     }
 
     companion object {
@@ -29,11 +29,11 @@ class MongoSourceOffset(offsetStr: String?) {
 
         /**
          * Start from current time will skip a lot of redundant scan on oplog
-         * Format: LATEST_TIMESTAMP,INC,OBJECT_ID,FINISH_IMPORT
+         * Format: LATEST_TIMESTAMP,INC,SORT_FIELD,FINISH_IMPORT
          */
-        fun toOffsetString(ts: BsonTimestamp, objectId: String, finishedImport: Boolean): String {
+        fun toOffsetString(ts: BsonTimestamp, sortField: String, finishedImport: Boolean): String {
             val finishedFlag = if (finishedImport) 1 else -1
-            return "${ts.time}$SPLITOR${ts.inc}$SPLITOR$objectId$SPLITOR$finishedFlag"
+            return "${ts.time}$SPLITOR${ts.inc}$SPLITOR$sortField$SPLITOR$finishedFlag"
         }
     }
 }

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/source/StructUtil.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/source/StructUtil.kt
@@ -12,6 +12,6 @@ object StructUtil {
 
     fun getTopic(message: Document, topicPrefix: String): String {
         val db = getDB(message).replace(".", "_")
-        return topicPrefix + "_" + db
+        return topicPrefix + "_" + db.toLowerCase()
     }
 }

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/source/StructUtil.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/source/StructUtil.kt
@@ -6,6 +6,8 @@ import org.bson.Document
  * @author Xu Jingxin
  */
 object StructUtil {
+    private val ejsonAsMillis = Regex("\\{\\s*\"\\\$date\"\\s*:\\s*(\\d+)\\s*}")
+
     fun getDB(message: Document): String {
         return message["ns"] as String
     }
@@ -13,5 +15,9 @@ object StructUtil {
     fun getTopic(message: Document, topicPrefix: String): String {
         val db = getDB(message).replace(".", "_")
         return topicPrefix + "_" + db
+    }
+
+    fun dateTimeAsMillis(json: String): String {
+      return ejsonAsMillis.replace(json, "\$1")
     }
 }

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/source/StructUtil.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/source/StructUtil.kt
@@ -12,6 +12,6 @@ object StructUtil {
 
     fun getTopic(message: Document, topicPrefix: String): String {
         val db = getDB(message).replace(".", "_")
-        return topicPrefix + "_" + db.toLowerCase()
+        return topicPrefix + "_" + db
     }
 }

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/tools/ImportData.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/tools/ImportData.kt
@@ -112,7 +112,7 @@ class ImportDB(val uri: String,
     private val mongoClient: MongoClient = MongoClient(MongoClientURI(uri))
     private val mongoDatabase: MongoDatabase
     private val mongoCollection: MongoCollection<Document>
-    private var offsetId: ObjectId? = null
+    private var offsetId: String? = null
     private val snakeDb: String = dbName.replace("\\.".toRegex(), "_")
     private var offsetCount = 0
     private val maxMessageSize = 3000
@@ -138,7 +138,7 @@ class ImportDB(val uri: String,
             .forEach {
                 try {
                     messages.add(getResult(it))
-                    offsetId = it["_id"] as ObjectId
+                    offsetId = it["_id"] as String
                     offsetCount += 1
                     while (messages.size > maxMessageSize) {
                         log.warn("Message overwhelm! database {}, docs {}, messages {}",
@@ -162,12 +162,12 @@ class ImportDB(val uri: String,
     }
 
     private fun getResult(document: Document): MessageData {
-        val id = document["_id"] as ObjectId
+        val id = document["_id"] as String
         val key = JSONObject(mapOf(
             "schema" to mapOf(
                 "type" to "string",
                 "optional" to true
-            ), "payload" to id.toHexString()
+            ), "payload" to id
         ))
         val topic = "${topicPrefix}_$snakeDb"
         val message = JSONObject(mapOf(
@@ -209,8 +209,8 @@ class ImportDB(val uri: String,
                 "name" to topic
             ),
             "payload" to mapOf(
-                "id" to id.toHexString(),
-                "ts" to id.timestamp,
+                "id" to id,
+                "ts" to document["createdAt"],
                 "inc" to 0,
                 "database" to snakeDb,
                 "op" to "i",

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/tools/ImportData.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/tools/ImportData.kt
@@ -169,7 +169,7 @@ class ImportDB(val uri: String,
                 "optional" to true
             ), "payload" to id
         ))
-        val topic = "${topicPrefix}_$snakeDb".toLowerCase()
+        val topic = "${topicPrefix}_$snakeDb"
         val message = JSONObject(mapOf(
             "schema" to mapOf(
                 "type" to "struct",

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/tools/ImportData.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/tools/ImportData.kt
@@ -210,7 +210,7 @@ class ImportDB(val uri: String,
             ),
             "payload" to mapOf(
                 "id" to id,
-                "ts" to document["createdAt"],
+                "ts" to document["updatedAt"],
                 "inc" to 0,
                 "database" to snakeDb,
                 "op" to "i",

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/tools/ImportData.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/tools/ImportData.kt
@@ -169,7 +169,7 @@ class ImportDB(val uri: String,
                 "optional" to true
             ), "payload" to id
         ))
-        val topic = "${topicPrefix}_$snakeDb"
+        val topic = "${topicPrefix}_$snakeDb".toLowerCase()
         val message = JSONObject(mapOf(
             "schema" to mapOf(
                 "type" to "struct",

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/tools/ImportData.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/tools/ImportData.kt
@@ -116,6 +116,7 @@ class ImportDB(val uri: String,
     private val snakeDb: String = dbName.replace("\\.".toRegex(), "_")
     private var offsetCount = 0
     private val maxMessageSize = 3000
+    private val ejsonDateAsLong: Regex = Regex("\\{ \"\\\$date\" : (\\d+) }")
 
     companion object {
         private val log = LoggerFactory.getLogger(ImportDB::class.java)
@@ -214,7 +215,7 @@ class ImportDB(val uri: String,
                 "inc" to 0,
                 "database" to snakeDb,
                 "op" to "i",
-                "object" to document.toJson()
+                "object" to ejsonDateAsLong.replace(document.toJson(), "\$1")
             )))
         return MessageData(topic, key, message)
     }

--- a/src/main/kotlin/com/teambition/kafka/connect/mongo/tools/ImportData.kt
+++ b/src/main/kotlin/com/teambition/kafka/connect/mongo/tools/ImportData.kt
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory
 import java.io.FileInputStream
 import java.util.*
 import java.util.concurrent.ConcurrentLinkedQueue
+import com.teambition.kafka.connect.mongo.source.StructUtil;
 
 data class MessageData(val topic: String,
                        val key: JSONObject,
@@ -116,7 +117,6 @@ class ImportDB(val uri: String,
     private val snakeDb: String = dbName.replace("\\.".toRegex(), "_")
     private var offsetCount = 0
     private val maxMessageSize = 3000
-    private val ejsonDateAsLong: Regex = Regex("\\{ \"\\\$date\" : (\\d+) }")
 
     companion object {
         private val log = LoggerFactory.getLogger(ImportDB::class.java)
@@ -215,7 +215,7 @@ class ImportDB(val uri: String,
                 "inc" to 0,
                 "database" to snakeDb,
                 "op" to "i",
-                "object" to ejsonDateAsLong.replace(document.toJson(), "\$1")
+                "object" to StructUtil.dateTimeAsMillis(document.toJson())
             )))
         return MessageData(topic, key, message)
     }


### PR DESCRIPTION
This is a _terrible hack_.

:jack_o_lantern: 

**The Problem**

`org.bson.Document.toJSON()` by default will use Extended JSON (EJSON) encoding for DateTime values, which looks like `{ "updatedAt" : { "$date" : 1543444797655 } }`.

This is undesirable for 2 main reasons:

1. It's a non-standard and unusual JSON encoding schema not widely adopted outside of the mongodb/meteor community
2. GraphQL by default forbids property names containing the $ character

I looked into less hacky ways to achieve this including:

- Configuring the .toJson()` call to use `JsonMode.STRICT` , but this is actually the default and still does EJSON
- Trying to configured the `org.bson.json.JsonWriterSettings` with a different converter for DateTime, but the constructor that would allow that is private

I think this will actually work, but it's probably a bit fragile.
